### PR TITLE
fix(farmer.js): Typo

### DIFF
--- a/src/farmer.js
+++ b/src/farmer.js
@@ -199,7 +199,7 @@ class Farmer extends FarmerBase {
         return false
       }
 
-      if (this.price) {
+      if (this.priceNum) {
         // Verify there is adequate budget in the job
         const jobId = toHexString(nonceString(agreement.getQuote().getSow()), { ethify: true })
         const budget = Number.parseFloat(await rewards.getBudget({ contentDid: this.afs.did, jobId }))


### PR DESCRIPTION
Fixes # Why `0.13.3` worked for me, but not` 0.14.0` :)

## Proposed Changes

  - Boolean `number` instead of `string`
